### PR TITLE
Improve prepare for json encode

### DIFF
--- a/src/pytest_respect/resources.py
+++ b/src/pytest_respect/resources.py
@@ -14,7 +14,7 @@ from pytest import FixtureRequest
 
 __tracebackhide__ = True  # Dont' include in pytest tracebacks
 
-from pytest_respect.utils import round_floats_in
+from pytest_respect.utils import prepare_for_json_encode
 
 DEFAULT_RESOURCES_DIR = "resources"
 
@@ -516,7 +516,7 @@ class TestResources:
         if ndigits is ...:
             ndigits = self.default_ndigits
         if ndigits is not None:
-            data = round_floats_in(data, ndigits=ndigits)
+            data = prepare_for_json_encode(data, ndigits=ndigits)
         text = self.json_encoder(data)
         if not text.endswith("\n"):
             text += "\n"

--- a/src/pytest_respect/utils.py
+++ b/src/pytest_respect/utils.py
@@ -29,7 +29,7 @@ def prepare_for_json_encode(struct: Any, *, ndigits: int | None = None) -> Any:
     # Special-case some leaf values
     if isinstance(struct, float):
         return round(struct, ndigits) if ndigits is not None else struct
-    elif isinstance(struct, dt.date|dt.time|dt.datetime):
+    elif isinstance(struct, dt.date | dt.time | dt.datetime):
         return struct.isoformat()
 
     # Convert struct recursively

--- a/tests/pytest_resources/test_utils.py
+++ b/tests/pytest_resources/test_utils.py
@@ -1,0 +1,133 @@
+import datetime as dt
+import json
+
+import numpy as np
+from pydantic import BaseModel
+
+from pytest_respect.utils import prepare_for_json_encode
+
+
+class PydanticModel(BaseModel):
+    name: str
+    weight: float
+    when: dt.datetime
+
+
+
+def test_prepare_for_json_encode__simple():
+    original = [
+        {
+            "f-zero": 0.123456789,
+            "i-zero": 0,
+            "s-zero": "0",
+        },
+        [1, 2, 3.333333333],
+        ("a", "b", 5.1234321),
+    ]
+
+    assert prepare_for_json_encode(original) == [
+        {
+            "f-zero": 0.123456789,
+            "i-zero": 0,
+            "s-zero": "0",
+        },
+        [1, 2, 3.333333333],
+        ("a", "b", 5.1234321),
+    ]
+
+def test_prepare_for_json_encode__round():
+    original = [
+        {
+            "f-zero": 0.123456789,
+            "i-zero": 0,
+            "s-zero": "0",
+        },
+        [1, 2, 3.333333333],
+        ("a", "b", 5.1234321),
+    ]
+
+    assert prepare_for_json_encode(original, ndigits=4) == [
+        {
+            "f-zero": 0.1235,  # last digit up
+            "i-zero": 0,
+            "s-zero": "0",
+        },
+        [1, 2, 3.3333],
+        ("a", "b", 5.1234),  # last digit down
+    ]
+
+
+def test_prepare_for_json_encode__date_and_time():
+    original = {
+        "date": dt.date(2025, 7, 22),
+        "time": dt.time(11, 9, 23),
+        "time_utc": dt.time(11, 9, 23, tzinfo=dt.timezone.utc),
+        "datetime": dt.datetime(2025, 7, 22, 11, 9, 23),
+        "datetime_utc": dt.datetime(2025, 7, 22, 11, 9, 23, tzinfo=dt.timezone.utc),
+    }
+
+    prepared = prepare_for_json_encode(original)
+
+    assert prepared == {
+        "date": "2025-07-22",
+        "datetime": "2025-07-22T11:09:23",
+        "datetime_utc": "2025-07-22T11:09:23+00:00",
+        "time": "11:09:23",
+        "time_utc": "11:09:23+00:00",
+    }
+    json.dumps(prepared)
+
+
+def test_prepare_for_json_encode__pydantic_model():
+    when = dt.datetime(1986, 3, 1, 12, 34, 56)
+    original = [
+        0.111111,
+        PydanticModel(name="foo", weight=75.4321, when=when),
+        0.555555,
+    ]
+
+    prepared = prepare_for_json_encode(original, ndigits=2)
+
+    assert prepared == [
+        0.11,
+        {"name": "foo", "weight": 75.43, "when": '1986-03-01T12:34:56'},
+        0.56,
+    ]
+    json.dumps(prepared)
+
+
+def test_prepare_for_json_encode__pydantic_model__json_mode():
+    when = dt.datetime(1986, 3, 1, 12, 34, 56)
+    original = [
+        0.111111,
+        PydanticModel(name="foo", weight=75.4321, when=when),
+        0.555555,
+    ]
+
+    prepared = prepare_for_json_encode(original, ndigits=2)
+
+
+    assert prepared == [
+        0.11,
+        {"name": "foo", "weight": 75.43, "when": "1986-03-01T12:34:56"},
+        0.56,
+    ]
+    json.dumps(prepared)
+
+
+def test_prepare_for_json_encode__numpy_array():
+    original = [
+        0.111111,
+        np.arange(2, 5) * 0.111111,
+        0.555555,
+    ]
+
+    prepared = prepare_for_json_encode(original, ndigits=2)
+
+    assert prepared == [
+        0.11,
+        [0.22, 0.33, 0.44],
+        0.56,
+    ]
+    json.dumps(prepared)
+

--- a/tests/pytest_resources/test_utils.py
+++ b/tests/pytest_resources/test_utils.py
@@ -13,7 +13,6 @@ class PydanticModel(BaseModel):
     when: dt.datetime
 
 
-
 def test_prepare_for_json_encode__simple():
     original = [
         {
@@ -34,6 +33,7 @@ def test_prepare_for_json_encode__simple():
         [1, 2, 3.333333333],
         ("a", "b", 5.1234321),
     ]
+
 
 def test_prepare_for_json_encode__round():
     original = [
@@ -90,7 +90,7 @@ def test_prepare_for_json_encode__pydantic_model():
 
     assert prepared == [
         0.11,
-        {"name": "foo", "weight": 75.43, "when": '1986-03-01T12:34:56'},
+        {"name": "foo", "weight": 75.43, "when": "1986-03-01T12:34:56"},
         0.56,
     ]
     json.dumps(prepared)
@@ -106,7 +106,6 @@ def test_prepare_for_json_encode__pydantic_model__json_mode():
 
     prepared = prepare_for_json_encode(original, ndigits=2)
 
-
     assert prepared == [
         0.11,
         {"name": "foo", "weight": 75.43, "when": "1986-03-01T12:34:56"},
@@ -118,9 +117,9 @@ def test_prepare_for_json_encode__pydantic_model__json_mode():
 def test_prepare_for_json_encode__numpy():
     original = [
         0.111111,
-        np.arange(2, 5) * 1/9,  # 1-D array
-        np.full((2,3), 10/3),  # 2-D array
-        np.full(1, 1/7)[0], # scalar
+        np.arange(2, 5) * 1 / 9,  # 1-D array
+        np.full((2, 3), 10 / 3),  # 2-D array
+        np.full(1, 1 / 7)[0],  # scalar
         0.555555,
     ]
     assert isinstance(original[-2], np.floating)
@@ -135,4 +134,3 @@ def test_prepare_for_json_encode__numpy():
         0.56,
     ]
     json.dumps(prepared)
-

--- a/tests/pytest_resources/test_utils.py
+++ b/tests/pytest_resources/test_utils.py
@@ -115,18 +115,23 @@ def test_prepare_for_json_encode__pydantic_model__json_mode():
     json.dumps(prepared)
 
 
-def test_prepare_for_json_encode__numpy_array():
+def test_prepare_for_json_encode__numpy():
     original = [
         0.111111,
-        np.arange(2, 5) * 0.111111,
+        np.arange(2, 5) * 1/9,  # 1-D array
+        np.full((2,3), 10/3),  # 2-D array
+        np.full(1, 1/7)[0], # scalar
         0.555555,
     ]
+    assert isinstance(original[-2], np.floating)
 
     prepared = prepare_for_json_encode(original, ndigits=2)
 
     assert prepared == [
         0.11,
         [0.22, 0.33, 0.44],
+        [[3.33, 3.33, 3.33], [3.33, 3.33, 3.33]],
+        0.14,
         0.56,
     ]
     json.dumps(prepared)


### PR DESCRIPTION
- Rename `round_floats_in` to more topical `prepare_for_json_encode`,
- Change the defaults for this more specific role
- Add conversion of date/time values to ISO strings. We make that conversion in the pre-processing rather than the JSON encoder because we support multiple json encoders and don't want to repeat this for each and every one of them.
- Copied the unit test for `round_float_in` from Ankeri Platform, adjusted and added tests for 100% coverage