### PR TITLE
Make it possible to override json_loader or json_encoder in individual resource calls

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Logi <logi@users.noreply.github.com>
+Logi <logi.ragnarsson@ankeri.is>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-MM-DD
+## [0.4.0] - Unreleased
+
+### Added
+
+- Added `resources.default` structure with defaults for `path_maker`, `json_loader`, `json_encoder` and `ndigits`.
+- Added optional `json_loader` argument to: `load_json`, `load_pydantic` and `load_pydantic_adapter` which overrides the default.
+- Added optional `json_encoder` argument to : `data_to_json`, `save_json`, `expect_json`, `save_pydantic`, `expect_pydantic`, `save_pydantic_adapter`, `expect_pydantic_adapter` to override the default.
+
+### Breaking
+
+- `resources.default_path_maker` was moved to `default.path_maker` and `default_ndigits` was moved to `default.ndigits`.
+
+## [0.3.0] - 2025-08-25
 
 ### Added
 

--- a/src/pytest_respect/plugin.py
+++ b/src/pytest_respect/plugin.py
@@ -7,7 +7,9 @@ from pytest_respect.resources import TestResources
 def resources(request: pytest.FixtureRequest) -> TestResources:
     """Load file resources relative to test functions and fixtures."""
     accept = request.config.getoption("--respect-accept")
-    return TestResources(request, ndigits=4, accept=accept)
+    resources = TestResources(request, accept=accept)
+    resources.default.ndigits = 4
+    return resources
 
 
 def pytest_addoption(parser):

--- a/src/pytest_respect/utils.py
+++ b/src/pytest_respect/utils.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from functools import partial
-from typing import Any
+from types import EllipsisType
+from typing import Any, Literal, TypeVar, overload
 
 # Optional imports falling back to stub implementations to make the type checker happy
 try:
@@ -13,6 +14,25 @@ try:
     from numpy import ndarray
 except ImportError:
     from ._fakes import ndarray, ndfloat
+
+T = TypeVar("T")
+
+
+@overload
+def coalesce(default: T | None | None, *args: T | None | EllipsisType, nonable: Literal[True]) -> T | None: ...
+@overload
+def coalesce(default: T, *args: T | None | EllipsisType, nonable: Literal[False]) -> T: ...
+@overload
+def coalesce(default: T, *args: T | None | EllipsisType) -> T: ...
+
+
+def coalesce(default: T | None, *args: T | None | EllipsisType, nonable: bool = False) -> T | None:
+    """Return the first value among default, *args that is not ... and, if nonable is Fals, is not None either."""
+    value: T | None = default
+    for arg in args:
+        if not isinstance(arg, EllipsisType) and (arg is not None or nonable is True):
+            value = arg
+    return value
 
 
 def prepare_for_json_encode(struct: Any, *, ndigits: int | None = None, allow_negative_zero: bool = False) -> Any:

--- a/tests/pytest_resources/ext/test_jsonyx.py
+++ b/tests/pytest_resources/ext/test_jsonyx.py
@@ -18,18 +18,17 @@ def resources(request: FixtureRequest) -> TestResources:
 
 
 def test_load_json__jsonyx_permissive(resources):
-    resources.json_loader = jsonyx_permissive_loader
-    data = resources.load_json()
+    data = resources.load_json(json_loader=jsonyx_permissive_loader)
     assert data == {"look": ["I", "found", "a", ANY]}
     assert isnan(data["look"][-1])
 
 
 def test_expected_json__jsonyx(resources):
-    resources.json_encoder = jsonyx_compactish_encoder
     resources.expect_json(
         {
             "look": ["what", "I", "found"],
             "numbers": [1, 2, 3, nan],
             "sub": {"simple": 1, "dict": 2, "is": 3, "flat": 4},
-        }
+        },
+        json_encoder=jsonyx_compactish_encoder,
     )

--- a/tests/pytest_resources/test_utils.py
+++ b/tests/pytest_resources/test_utils.py
@@ -3,6 +3,8 @@ import json
 
 import pytest
 
+from pytest_respect.utils import coalesce, prepare_for_json_encode
+
 # Optional imports, falling back to stub classes
 try:
     from pydantic import BaseModel
@@ -10,7 +12,25 @@ except ImportError:
     from pytest_respect._fakes import BaseModel
 
 
-from pytest_respect.utils import prepare_for_json_encode
+def test_coalesce__given():
+    assert coalesce(42, None, ..., 888, None, ...) == 888
+
+
+def test_coalesce__not_given():
+    assert coalesce(42, None, ...) == 42
+
+
+def test_coalesce__nonable__given__not_none():
+    assert coalesce(42, 888, ..., nonable=True) == 888
+
+
+def test_coalesce__nonable__given__none():
+    assert coalesce(42, None, ..., nonable=True) is None
+
+
+@pytest.mark.parametrize("default", [42, None])
+def test_coalesce__nonable__not_given(default):
+    assert coalesce(default, ..., ..., nonable=True) == default
 
 
 def test_prepare_for_json_encode__simple():


### PR DESCRIPTION
- Moves the defaults into a new `resources.default` structure
- Adds helper functions to resolve effective value given the default and optional override
- Adds optional `json_loader` and `json_encoder` arguments to lots of load, save and expect methods.